### PR TITLE
implementation only in asc

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,5 @@ exports.asc = function (a, b) {
 };
 
 exports.desc = function (a, b) {
-	return a === b ? 0 : b.localeCompare(a);
+	return exports.asc(b, a);
 };

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var alphaSort = require('./');
 
 test(function (t) {
 	t.assert(['b', 'a', 'c'].sort(alphaSort.asc)[0] === 'a');
+	t.assert(['a', 'A', 'c'].sort(alphaSort.asc)[0] === 'A');
 	t.assert(['b', 'a', 'c'].sort(alphaSort.desc)[0] === 'c');
 	t.assert(['b', 'å', 'c'].sort(alphaSort.desc)[0] === 'å');
 	t.end();


### PR DESCRIPTION
Implement logic only in `asc`. So future enhancements (#1) can be implemented in one place.
