### PR TITLE
Add case-insensitive comparators

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,3 +25,29 @@ import alphaSort = require('alpha-sort');
 ```
 */
 export const descending: StringComparator;
+
+/**
+Case-insensitive ascending sort comparator.
+
+@example
+```
+import alphaSort = require('alpha-sort');
+
+['B', 'a', 'C'].sort(alphaSort.caseInsensitiveAscending);
+//=> ['a', 'B', 'C']
+```
+*/
+export const caseInsensitiveAscending: StringComparator;
+
+/**
+Case-insensitive descending sort comparator.
+
+@example
+```
+import alphaSort = require('alpha-sort');
+
+['B', 'a', 'C'].sort(alphaSort.caseInsensitiveDescending);
+//=> ['C', 'B', 'a']
+```
+*/
+export const caseInsensitiveDescending: StringComparator;

--- a/index.js
+++ b/index.js
@@ -8,5 +8,12 @@ if (brokenLocaleCompare) {
 	compare = (left, right) => left > right ? 1 : left < right ? -1 : 0;
 }
 
+function caseInsensitiveCompare(left, right) {
+	const lowercaseComparison = compare(left.toLowerCase(), right.toLowerCase());
+	return lowercaseComparison === 0 ? compare(left, right) : lowercaseComparison;
+}
+
 exports.ascending = (left, right) => compare(left, right);
 exports.descending = (left, right) => compare(right, left);
+exports.caseInsensitiveAscending = (left, right) => caseInsensitiveCompare(left, right);
+exports.caseInsensitiveDescending = (left, right) => caseInsensitiveCompare(right, left);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,6 +3,10 @@ import alphaSort = require('.');
 
 expectType<number>(alphaSort.ascending('a', 'b'));
 expectType<number>(alphaSort.descending('a', 'b'));
+expectType<number>(alphaSort.caseInsensitiveAscending('a', 'b'));
+expectType<number>(alphaSort.caseInsensitiveDescending('a', 'b'));
 
 ['b', 'a', 'c'].sort(alphaSort.ascending);
 ['b', 'a', 'c'].sort(alphaSort.descending);
+['b', 'a', 'c'].sort(alphaSort.caseInsensitiveAscending);
+['b', 'a', 'c'].sort(alphaSort.caseInsensitiveDescending);

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,25 @@ Ascending sort comparator.
 
 Descending sort comparator.
 
+### alphaSort.caseInsensitiveAscending
+
+Case-insensitive ascending sort comparator.
+
+Note: If two elements are considered equal in the case-insensitive comparison, the tie-break will be a case-sensitive comparison:
+
+```js
+const alphaSort = require('alpha-sort');
+
+['bar', 'baz', 'Baz'].sort(alphaSort.caseInsensitiveAscending);
+//=> ['bar', 'Baz', 'baz']
+```
+
+### alphaSort.caseInsensitiveDescending
+
+Case-insensitive descending sort comparator.
+
+The same note for `caseInsensitiveAscending` applies.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -2,9 +2,27 @@ import test from 'ava';
 import alphaSort from '.';
 
 test('main', t => {
+	// If any of them were undefined, the `sort` call might luckily pass
+	t.truthy(alphaSort.ascending);
+	t.truthy(alphaSort.descending);
+	t.truthy(alphaSort.caseInsensitiveAscending);
+	t.truthy(alphaSort.caseInsensitiveDescending);
+
 	t.deepEqual(['b', 'a', 'c'].sort(alphaSort.ascending), ['a', 'b', 'c']);
 	t.deepEqual(['b', 'å', 'c'].sort(alphaSort.ascending), ['b', 'c', 'å']);
 	t.deepEqual(['b', 'a', 'c'].sort(alphaSort.descending), ['c', 'b', 'a']);
 	t.deepEqual(['b', 'å', 'c'].sort(alphaSort.descending), ['å', 'c', 'b']);
 	t.deepEqual(['b', '🦄', 'c'].sort(alphaSort.ascending), ['b', 'c', '🦄']);
+	t.deepEqual(['B', 'a', 'C'].sort(alphaSort.caseInsensitiveAscending), ['a', 'B', 'C']);
+	t.deepEqual(['B', 'a', 'C'].sort(alphaSort.caseInsensitiveDescending), ['C', 'B', 'a']);
+	t.deepEqual(['bar', 'baz', 'Baz'].sort(alphaSort.caseInsensitiveAscending), ['bar', 'Baz', 'baz']);
+
+	t.deepEqual(
+		['C', 'åa', 'd', 'A', 'Åb', 'b', 'B', 'bar', 'Bar'].sort(alphaSort.caseInsensitiveAscending),
+		['A', 'B', 'b', 'Bar', 'bar', 'C', 'd', 'åa', 'Åb']
+	);
+	t.deepEqual(
+		['C', 'åa', 'd', 'A', 'Åb', 'b', 'B', 'bar', 'Bar'].sort(alphaSort.caseInsensitiveDescending),
+		['Åb', 'åa', 'd', 'C', 'bar', 'Bar', 'b', 'B', 'A']
+	);
 });


### PR DESCRIPTION
This PR adds `alphaSort.caseInsensitiveAscending` and `alphaSort.caseInsensitiveDescending`.

Closes #6 