### PR TITLE
Major API changes; add `natural` and `preprocessor` options

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -9,21 +9,21 @@ if (brokenLocaleCompare) {
 }
 
 function naturalCompare(left, right) {
-	const naturalSplitRegex = /(\d+)/; // Parentheses are important
+	const naturalSplitRegex = /(\d+)/; // Parentheses are important.
 
 	const leftChunks = left.split(naturalSplitRegex);
 	const rightChunks = right.split(naturalSplitRegex);
 
-	// If the first chunk doesn't match, the `natural` option is irrelevant
+	// If the first chunk doesn't match, the `natural` option is irrelevant.
 	if (leftChunks[0] !== rightChunks[0]) {
 		return baseCompare(left, right);
 	}
 
 	const maxValidIndex = Math.min(leftChunks.length, rightChunks.length) - 1;
 
-	// Note that `maxValidIndex` is guaranteed to be even
+	// Note that `maxValidIndex` is guaranteed to be even.
 	for (let i = 1; i < maxValidIndex; i += 2) {
-		// For odd indexes, values surely match /^\d+$/
+		// For odd indexes, values surely match `/^\d+$/`.
 		const leftNumber = Number.parseInt(leftChunks[i], 10);
 		const rightNumber = Number.parseInt(rightChunks[i], 10);
 
@@ -31,10 +31,10 @@ function naturalCompare(left, right) {
 			return leftNumber - rightNumber;
 		}
 
-		// If we're here, the numbers were equal
+		// If we're here, the numbers were equal.
 
-		// For even indexes, values surely don't match /\d/
-		// If they are not identical, the `natural` option becomes irrelevant
+		// For even indexes, values surely don't match `/\d/`.
+		// If they are not identical, the `natural` option becomes irrelevant.
 		if (leftChunks[i + 1] !== rightChunks[i + 1]) {
 			return baseCompare(
 				leftChunks.slice(i + 1).join(''),

--- a/compare.js
+++ b/compare.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const collator = new Intl.Collator();
+let baseCompare = (left, right) => left === right ? 0 : collator.compare(left, right);
+
+const brokenLocaleCompare = collator.compare('b', 'å') > -1;
+if (brokenLocaleCompare) {
+	baseCompare = (left, right) => left > right ? 1 : left < right ? -1 : 0;
+}
+
+function naturalCompare(left, right) {
+	const naturalSplitRegex = /(\d+)/; // Parentheses are important
+
+	const leftChunks = left.split(naturalSplitRegex);
+	const rightChunks = right.split(naturalSplitRegex);
+
+	// If the first chunk doesn't match, the `natural` option is irrelevant
+	if (leftChunks[0] !== rightChunks[0]) {
+		return baseCompare(left, right);
+	}
+
+	const maxValidIndex = Math.min(leftChunks.length, rightChunks.length) - 1;
+
+	// Note that `maxValidIndex` is guaranteed to be even
+	for (let i = 1; i < maxValidIndex; i += 2) {
+		// For odd indexes, values surely match /^\d+$/
+		const leftNumber = Number.parseInt(leftChunks[i], 10);
+		const rightNumber = Number.parseInt(rightChunks[i], 10);
+
+		if (leftNumber !== rightNumber) {
+			return leftNumber - rightNumber;
+		}
+
+		// If we're here, the numbers were equal
+
+		// For even indexes, values surely don't match /\d/
+		// If they are not identical, the `natural` option becomes irrelevant
+		if (leftChunks[i + 1] !== rightChunks[i + 1]) {
+			return baseCompare(
+				leftChunks.slice(i + 1).join(''),
+				rightChunks.slice(i + 1).join('')
+			);
+		}
+	}
+
+	// If we're here, the comparison is fully tied with the `natural` option.
+	return baseCompare(left, right);
+}
+
+module.exports = {baseCompare, naturalCompare};

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,19 +12,45 @@ declare namespace alphaSort {
 		/**
 		Whether or not to sort case-insensitively.
 
+		Note: If two elements are considered equal in the case-insensitive comparison, the tie-break will be a standard (case-sensitive) comparison.
+
+		@example
+		```
+		const alphaSort = require('alpha-sort');
+
+		['bar', 'baz', 'Baz'].sort(alphaSort({caseInsensitive: true}));
+		//=> ['bar', 'Baz', 'baz']
+		```
+
 		@default false
 		*/
 		readonly caseInsensitive?: boolean;
 
 		/**
-		Whether or not to respect the natural order of numbers in the string (such as sorting `10` after `2`).
+		Whether or not to sort using natural sort order (such as sorting `10` after `2`).
+
+		Note: If two elements are considered equal in the natural sort order comparison, the tie-break will be a standard (non-natural) comparison.
 
 		@default false
 		*/
 		readonly natural?: boolean;
 
 		/**
-		A custom preprocessor to execute on the strings before sorting. The array is not modified.
+		A custom function that you can provide to manipulate the elements before sorting. This does not modify the values of the array; it only interferes in the sorting order.
+
+		This can be used, for example, if you are sorting book titles in English and want to ignore common articles such as `the`, `a` or `an`.
+
+		Note: If two elements are considered equal when sorting with a custom preprocessor, the tie-break will be a comparison without the custom preprocessor.
+
+		@example
+		```
+		const alphaSort = require('alpha-sort');
+
+		['The Foo', 'Bar'].sort(alphaSort({
+			preprocessor: title => title.replace(/^(?:the|a|an) /i, '')
+		}));
+		//=> ['Bar', 'The Foo']
+		```
 
 		@default undefined
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,14 @@ declare namespace alphaSort {
 		Note: If two elements are considered equal in the natural sort order comparison, the tie-break will be a standard (non-natural) comparison.
 
 		@default false
+
+		@example
+		```
+		import alphaSort = require('alpha-sort');
+
+		['file10.txt', 'file05.txt', 'file0010.txt'].sort(alphaSort({natural: true}));
+		//=> ['file05.txt', 'file0010.txt', 'file10.txt']
+		```
 		*/
 		readonly natural?: boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,15 +14,15 @@ declare namespace alphaSort {
 
 		Note: If two elements are considered equal in the case-insensitive comparison, the tie-break will be a standard (case-sensitive) comparison.
 
+		@default false
+
 		@example
 		```
-		const alphaSort = require('alpha-sort');
+		import alphaSort = require('alpha-sort');
 
 		['bar', 'baz', 'Baz'].sort(alphaSort({caseInsensitive: true}));
 		//=> ['bar', 'Baz', 'baz']
 		```
-
-		@default false
 		*/
 		readonly caseInsensitive?: boolean;
 
@@ -42,17 +42,17 @@ declare namespace alphaSort {
 
 		Note: If two elements are considered equal when sorting with a custom preprocessor, the tie-break will be a comparison without the custom preprocessor.
 
+		@default undefined
+
 		@example
 		```
-		const alphaSort = require('alpha-sort');
+		import alphaSort = require('alpha-sort');
 
 		['The Foo', 'Bar'].sort(alphaSort({
 			preprocessor: title => title.replace(/^(?:the|a|an) /i, '')
 		}));
 		//=> ['Bar', 'The Foo']
 		```
-
-		@default undefined
 		*/
 		readonly preprocessor?: (string: string) => string;
 	}
@@ -66,7 +66,7 @@ declare const alphaSort: {
 
 	@example
 	```
-	const alphaSort = require('alpha-sort');
+	import alphaSort = require('alpha-sort');
 
 	['b', 'a', 'c'].sort(alphaSort());
 	//=> ['a', 'b', 'c']

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,53 +1,61 @@
-export type StringComparator = (left: string, right: string) => number;
+declare namespace alphaSort {
+	type StringComparator = (left: string, right: string) => number;
 
-/**
-Ascending sort comparator.
+	type Options = {
+		/**
+		Whether or not to sort in descending order.
 
-@example
-```
-import alphaSort = require('alpha-sort');
+		@default false
+		*/
+		readonly descending?: boolean;
 
-['b', 'a', 'c'].sort(alphaSort.ascending);
-//=> ['a', 'b', 'c']
-```
-*/
-export const ascending: StringComparator;
+		/**
+		Whether or not to sort case-insensitively.
 
-/**
-Descending sort comparator.
+		@default false
+		*/
+		readonly caseInsensitive?: boolean;
 
-@example
-```
-import alphaSort = require('alpha-sort');
+		/**
+		Whether or not to respect the natural order of numbers in the string (such as sorting `10` after `2`).
 
-['b', 'a', 'c'].sort(alphaSort.descending);
-//=> ['c', 'b', 'a']
-```
-*/
-export const descending: StringComparator;
+		@default false
+		*/
+		readonly natural?: boolean;
 
-/**
-Case-insensitive ascending sort comparator.
+		/**
+		A custom preprocessor to execute on the strings before sorting. The array is not modified.
 
-@example
-```
-import alphaSort = require('alpha-sort');
+		@default undefined
+		*/
+		readonly preprocessor?: (string: string) => string;
+	}
+}
 
-['B', 'a', 'C'].sort(alphaSort.caseInsensitiveAscending);
-//=> ['a', 'B', 'C']
-```
-*/
-export const caseInsensitiveAscending: StringComparator;
+declare const alphaSort: {
+	/**
+	Get a comparator function to be used as argument for `Array#sort`.
 
-/**
-Case-insensitive descending sort comparator.
+	@param options - Choose ascending/descending, case sensitivity, and number natural ordering.
 
-@example
-```
-import alphaSort = require('alpha-sort');
+	@example
+	```
+	const alphaSort = require('alpha-sort');
 
-['B', 'a', 'C'].sort(alphaSort.caseInsensitiveDescending);
-//=> ['C', 'B', 'a']
-```
-*/
-export const caseInsensitiveDescending: StringComparator;
+	['b', 'a', 'c'].sort(alphaSort());
+	//=> ['a', 'b', 'c']
+
+	['b', 'a', 'c'].sort(alphaSort({descending: true}));
+	//=> ['c', 'b', 'a']
+
+	['B', 'a', 'C'].sort(alphaSort({caseInsensitive: true}));
+	//=> ['a', 'B', 'C']
+
+	['file10.txt', 'file2.txt', 'file03.txt'].sort(alphaSort({natural: true}));
+	//=> ['file2.txt', 'file03.txt', 'file10.txt']
+	```
+	*/
+	(options?: alphaSort.Options): alphaSort.StringComparator;
+};
+
+export = alphaSort;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,19 @@
 import {expectType} from 'tsd';
 import alphaSort = require('.');
 
-expectType<number>(alphaSort.ascending('a', 'b'));
-expectType<number>(alphaSort.descending('a', 'b'));
-expectType<number>(alphaSort.caseInsensitiveAscending('a', 'b'));
-expectType<number>(alphaSort.caseInsensitiveDescending('a', 'b'));
+declare const options: {
+	descending?: boolean;
+	natural?: boolean;
+	caseInsensitive?: boolean;
+	preprocessor?: (string: string) => string;
+} | undefined;
 
-['b', 'a', 'c'].sort(alphaSort.ascending);
-['b', 'a', 'c'].sort(alphaSort.descending);
-['b', 'a', 'c'].sort(alphaSort.caseInsensitiveAscending);
-['b', 'a', 'c'].sort(alphaSort.caseInsensitiveDescending);
+expectType<Parameters<typeof alphaSort>[0]>(options);
+
+expectType<number>(alphaSort()('a', 'b'));
+expectType<number>(alphaSort({})('a', 'b'));
+expectType<number>(alphaSort(options)('a', 'b'));
+
+['b', 'a', 'c'].sort(alphaSort());
+['b', 'a', 'c'].sort(alphaSort({}));
+['b', 'a', 'c'].sort(alphaSort(options));

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
 		"test": "xo && ava && tsd"
 	},
 	"files": [
-		"compare.js",
 		"index.js",
-		"index.d.ts"
+		"index.d.ts",
+		"compare.js"
 	],
 	"keywords": [
 		"alpha",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"test": "xo && ava && tsd"
 	},
 	"files": [
+		"compare.js",
 		"index.js",
 		"index.d.ts"
 	],
@@ -23,14 +24,17 @@
 		"alpha",
 		"alphabet",
 		"alphabetically",
+		"lexicographically",
 		"sort",
 		"compare",
 		"comparator",
+		"order",
 		"locale",
 		"unicode",
 		"string",
 		"intl",
-		"collator"
+		"collator",
+		"natural"
 	],
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ Note: If two elements are considered equal in the natural sort order comparison,
 Type: `function`\
 Default: `undefined`
 
-A custom function that you can provide to manipulate the elements before sorting. This does not modify the original array nor the output values (only the output order).
+A custom function that you can provide to manipulate the elements before sorting. This does not modify the values of the array; it only interferes in the sorting order.
 
 This can be used, for example, if you are sorting book titles in English and want to ignore common articles such as `the`, `a` or `an`:
 

--- a/readme.md
+++ b/readme.md
@@ -46,14 +46,14 @@ Type: `object`
 Type: `boolean`\
 Default: `false`
 
-Whether or not to sort descending.
+Whether or not to sort in descending order.
 
 ##### caseInsensitive
 
 Type: `boolean`\
 Default: `false`
 
-Whether or not to sort in a case-insensitive way.
+Whether or not to sort case-insensitively.
 
 Note: If two elements are considered equal in the case-insensitive comparison, the tie-break will be a standard (case-sensitive) comparison. Example:
 
@@ -69,7 +69,7 @@ const alphaSort = require('alpha-sort');
 Type: `boolean`\
 Default: `false`
 
-Whether or not to sort using [natural sort order](https://en.wikipedia.org/wiki/Natural_sort_order).
+Whether or not to sort using [natural sort order](https://en.wikipedia.org/wiki/Natural_sort_order) (such as sorting `10` after `2`).
 
 Note: If two elements are considered equal in the natural sort order comparison, the tie-break will be a standard (non-natural) comparison.
 
@@ -86,7 +86,7 @@ This can be used, for example, if you are sorting book titles in English and wan
 const alphaSort = require('alpha-sort');
 
 ['The Foo', 'Bar'].sort(alphaSort({
-	preprocessor: title => title.replace(/^(the|a|an) /i, '')
+	preprocessor: title => title.replace(/^(?:the|a|an) /i, '')
 }));
 //=> ['Bar', 'The Foo']
 ```

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,14 @@ Default: `false`
 
 Whether or not to sort using [natural sort order](https://en.wikipedia.org/wiki/Natural_sort_order) (such as sorting `10` after `2`).
 
-Note: If two elements are considered equal in the natural sort order comparison, the tie-break will be a standard (non-natural) comparison.
+Note: If two elements are considered equal in the natural sort order comparison, the tie-break will be a standard (non-natural) comparison. Example:
+
+```js
+const alphaSort = require('alpha-sort');
+
+['file10.txt', 'file05.txt', 'file0010.txt'].sort(alphaSort({natural: true}));
+//=> ['file05.txt', 'file0010.txt', 'file10.txt']
+```
 
 ##### preprocessor
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Alphabetically sort an array of strings
 
-With correct sorting of unicode characters.
+With correct sorting of unicode characters. Supports [natural sort order](https://en.wikipedia.org/wiki/Natural_sort_order) with an option.
 
 
 ## Install
@@ -17,39 +17,81 @@ $ npm install alpha-sort
 ```js
 const alphaSort = require('alpha-sort');
 
-['b', 'a', 'c'].sort(alphaSort.ascending);
+['b', 'a', 'c'].sort(alphaSort());
 //=> ['a', 'b', 'c']
+
+['b', 'a', 'c'].sort(alphaSort({descending: true}));
+//=> ['c', 'b', 'a']
+
+['B', 'a', 'C'].sort(alphaSort({caseInsensitive: true}));
+//=> ['a', 'B', 'C']
+
+['file10.txt', 'file2.txt', 'file03.txt'].sort(alphaSort({natural: true}));
+//=> ['file2.txt', 'file03.txt', 'file10.txt']
 ```
 
 
 ## API
 
-### alphaSort.ascending
+### alphaSort(options?)
 
-Ascending sort comparator.
+Get a comparator function to be used as argument for [`Array#sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
 
-### alphaSort.descending
+#### options
 
-Descending sort comparator.
+Type: `object`
 
-### alphaSort.caseInsensitiveAscending
+##### descending
 
-Case-insensitive ascending sort comparator.
+Type: `boolean`\
+Default: `false`
 
-Note: If two elements are considered equal in the case-insensitive comparison, the tie-break will be a case-sensitive comparison:
+Whether or not to sort descending.
+
+##### caseInsensitive
+
+Type: `boolean`\
+Default: `false`
+
+Whether or not to sort in a case-insensitive way.
+
+Note: If two elements are considered equal in the case-insensitive comparison, the tie-break will be a standard (case-sensitive) comparison. Example:
 
 ```js
 const alphaSort = require('alpha-sort');
 
-['bar', 'baz', 'Baz'].sort(alphaSort.caseInsensitiveAscending);
+['bar', 'baz', 'Baz'].sort(alphaSort({caseInsensitive: true}));
 //=> ['bar', 'Baz', 'baz']
 ```
 
-### alphaSort.caseInsensitiveDescending
+##### natural
 
-Case-insensitive descending sort comparator.
+Type: `boolean`\
+Default: `false`
 
-The same note for `caseInsensitiveAscending` applies.
+Whether or not to sort using [natural sort order](https://en.wikipedia.org/wiki/Natural_sort_order).
+
+Note: If two elements are considered equal in the natural sort order comparison, the tie-break will be a standard (non-natural) comparison.
+
+##### preprocessor
+
+Type: `function`\
+Default: `undefined`
+
+A custom function that you can provide to manipulate the elements before sorting. This does not modify the original array nor the output values (only the output order).
+
+This can be used, for example, if you are sorting book titles in English and want to ignore common articles such as `the`, `a` or `an`:
+
+```js
+const alphaSort = require('alpha-sort');
+
+['The Foo', 'Bar'].sort(alphaSort({
+	preprocessor: title => title.replace(/^(the|a|an) /i, '')
+}));
+//=> ['Bar', 'The Foo']
+```
+
+Note: If two elements are considered equal when sorting with a custom preprocessor, the tie-break will be a comparison without the custom preprocessor.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -48,6 +48,12 @@ test('`natural` option', t => {
 		alreadyInNaturalOrder.slice().sort(alphaSort({descending: true, natural: true})),
 		alreadyInNaturalOrder.slice().reverse()
 	);
+
+	// Check tie-breaking
+	t.deepEqual(
+		['file10.txt', 'file05.txt', 'file0010.txt'].sort(alphaSort({natural: true})),
+		['file05.txt', 'file0010.txt', 'file10.txt']
+	);
 });
 
 test('`preprocessor` option', t => {

--- a/test.js
+++ b/test.js
@@ -2,27 +2,100 @@ import test from 'ava';
 import alphaSort from '.';
 
 test('main', t => {
-	// If any of them were undefined, the `sort` call might luckily pass
-	t.truthy(alphaSort.ascending);
-	t.truthy(alphaSort.descending);
-	t.truthy(alphaSort.caseInsensitiveAscending);
-	t.truthy(alphaSort.caseInsensitiveDescending);
+	t.is(typeof alphaSort(), 'function');
 
-	t.deepEqual(['b', 'a', 'c'].sort(alphaSort.ascending), ['a', 'b', 'c']);
-	t.deepEqual(['b', 'å', 'c'].sort(alphaSort.ascending), ['b', 'c', 'å']);
-	t.deepEqual(['b', 'a', 'c'].sort(alphaSort.descending), ['c', 'b', 'a']);
-	t.deepEqual(['b', 'å', 'c'].sort(alphaSort.descending), ['å', 'c', 'b']);
-	t.deepEqual(['b', '🦄', 'c'].sort(alphaSort.ascending), ['b', 'c', '🦄']);
-	t.deepEqual(['B', 'a', 'C'].sort(alphaSort.caseInsensitiveAscending), ['a', 'B', 'C']);
-	t.deepEqual(['B', 'a', 'C'].sort(alphaSort.caseInsensitiveDescending), ['C', 'B', 'a']);
-	t.deepEqual(['bar', 'baz', 'Baz'].sort(alphaSort.caseInsensitiveAscending), ['bar', 'Baz', 'baz']);
+	t.deepEqual(['b', 'a', 'c'].sort(alphaSort()), ['a', 'b', 'c']);
+	t.deepEqual(['b', 'å', 'c'].sort(alphaSort()), ['b', 'c', 'å']);
+	t.deepEqual(['b', '🦄', 'c'].sort(alphaSort()), ['b', 'c', '🦄']);
+
+	t.deepEqual(['b', 'a', 'c'].sort(alphaSort({descending: true})), ['c', 'b', 'a']);
+	t.deepEqual(['b', 'å', 'c'].sort(alphaSort({descending: true})), ['å', 'c', 'b']);
+	t.deepEqual(['b', '🦄', 'c'].sort(alphaSort({descending: true})), ['🦄', 'c', 'b']);
+});
+
+test('case insensitive', t => {
+	t.deepEqual(['B', 'a', 'C'].sort(alphaSort({caseInsensitive: true})), ['a', 'B', 'C']);
+	t.deepEqual(['B', 'a', 'C'].sort(alphaSort({descending: true, caseInsensitive: true})), ['C', 'B', 'a']);
+	t.deepEqual(['bar', 'baz', 'Baz'].sort(alphaSort({caseInsensitive: true})), ['bar', 'Baz', 'baz']);
 
 	t.deepEqual(
-		['C', 'åa', 'd', 'A', 'Åb', 'b', 'B', 'bar', 'Bar'].sort(alphaSort.caseInsensitiveAscending),
+		['C', 'åa', 'd', 'A', 'Åb', 'b', 'B', 'bar', 'Bar'].sort(alphaSort({caseInsensitive: true})),
 		['A', 'B', 'b', 'Bar', 'bar', 'C', 'd', 'åa', 'Åb']
 	);
 	t.deepEqual(
-		['C', 'åa', 'd', 'A', 'Åb', 'b', 'B', 'bar', 'Bar'].sort(alphaSort.caseInsensitiveDescending),
+		['C', 'åa', 'd', 'A', 'Åb', 'b', 'B', 'bar', 'Bar'].sort(alphaSort({descending: true, caseInsensitive: true})),
 		['Åb', 'åa', 'd', 'C', 'bar', 'Bar', 'b', 'B', 'A']
+	);
+});
+
+test('natural', t => {
+	const numbers = length => [...new Array(length)].map((_, index) => String(index));
+
+	t.deepEqual(
+		numbers(200).reverse().sort(alphaSort({natural: true})),
+		numbers(200)
+	);
+
+	t.deepEqual(
+		['file10.txt', 'file2.txt', 'file03.txt'].sort(alphaSort({natural: true})),
+		['file2.txt', 'file03.txt', 'file10.txt']
+	);
+
+	const alreadyInNaturalOrder = [
+		'a', 'a0', 'a1x', 'a2', 'a03x4', 'a003x10', 'a03x10', 'a003y', 'a10', 'abc'
+	];
+	t.deepEqual(
+		alreadyInNaturalOrder.slice().sort(alphaSort({descending: true, natural: true})),
+		alreadyInNaturalOrder.slice().reverse()
+	);
+});
+
+test('preprocessor', t => {
+	t.deepEqual(
+		['The Foo', 'Bar'].sort(alphaSort({
+			preprocessor: title => title.replace(/^(the|a|an) /i, '')
+		})),
+		['Bar', 'The Foo']
+	);
+
+	const preprocessor = string => string.slice(1); // Strip first character
+
+	t.deepEqual(
+		['a9', 'b5', 'z10a', 'c3', 'z10B'].sort(alphaSort({preprocessor})),
+		['z10B', 'z10a', 'c3', 'b5', 'a9']
+	);
+
+	t.deepEqual(
+		['a9', 'b5', 'z10a', 'c3', 'z10B'].sort(alphaSort({preprocessor, descending: true})),
+		['a9', 'b5', 'c3', 'z10a', 'z10B']
+	);
+
+	t.deepEqual(
+		['a9', 'b5', 'z10a', 'c3', 'z10B'].sort(alphaSort({preprocessor, natural: true})),
+		['c3', 'b5', 'a9', 'z10B', 'z10a']
+	);
+
+	t.deepEqual(
+		['a9', 'b5', 'z10a', 'c3', 'z10B'].sort(alphaSort({preprocessor, natural: true, caseInsensitive: true})),
+		['c3', 'b5', 'a9', 'z10a', 'z10B']
+	);
+
+	t.deepEqual(
+		['a9', 'b5', 'z10a', 'c3', 'z10B'].sort(alphaSort({
+			preprocessor,
+			descending: true,
+			natural: true,
+			caseInsensitive: true
+		})),
+		['z10B', 'z10a', 'a9', 'b5', 'c3']
+	);
+});
+
+test('helpful error on mistake', t => {
+	t.throws(
+		() => ['foo', 'bar'].sort(alphaSort),
+		{
+			message: 'Invalid `alphaSort` call. Did you use `.sort(alphaSort)` instead of `.sort(alphaSort())` by mistake?'
+		}
 	);
 });

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ test('case insensitive', t => {
 	);
 });
 
-test('natural', t => {
+test('`natural` option', t => {
 	const numbers = length => [...new Array(length)].map((_, index) => String(index));
 
 	t.deepEqual(
@@ -50,7 +50,7 @@ test('natural', t => {
 	);
 });
 
-test('preprocessor', t => {
+test('`preprocessor` option', t => {
 	t.deepEqual(
 		['The Foo', 'Bar'].sort(alphaSort({
 			preprocessor: title => title.replace(/^(the|a|an) /i, '')


### PR DESCRIPTION
Closes #8

Hello! I decided to take a different approach than the `ignorePrefixes` option we discussed in #8. I think you will like it.

* This PR changes the API to receive an options object of the form `{ descending, caseInsensitive, natural, preprocessor }` instead of using properties such as `.ascending` and `.caseInsensitiveAscending`.

* This PR adds a `natural` option which treats any sequence of digits `/\d+/` atomically.

* This PR adds a `preprocessor` option which is not only much more powerful than the `ignorePrefixes` idea but also cleaner in my opinion. I started developing the `ignorePrefixes` but I was thinking it was too cumbersome and specific.

* I have added an example in readme on how the new `preprocessor` option can be used to easily obtain the behavior desired by OP in #8.